### PR TITLE
Grigorchuk Group

### DIFF
--- a/gap/SRGroups.gd
+++ b/gap/SRGroups.gd
@@ -59,6 +59,7 @@ DeclareCategory("IsRegularRootedTreeGroup", IsPermGroup);
 
 ##################################################################################################################
 
+#! @BeginGroup RegularRootedTreeGroupDegree
 #! @Description
 #! The argument of this attribute is a regular rooted tree group <A>G</A>.
 #!
@@ -74,8 +75,14 @@ DeclareAttribute("RegularRootedTreeGroupDegree", IsRegularRootedTreeGroup);
 #! 2
 #! @EndExampleSession
 
+#! @Arguments G
+#!
+DeclareOperation( "Degree", [IsRegularRootedTreeGroup] );
+#! @EndGroup
+
 ##################################################################################################################
 
+#! @BeginGroup RegularRootedTreeGroupDepth
 #! @Description
 #! The argument of this attribute is a regular rooted tree group <A>G</A>.
 #!
@@ -90,6 +97,15 @@ DeclareAttribute("RegularRootedTreeGroupDepth", IsRegularRootedTreeGroup);
 #! gap> RegularRootedTreeGroupDepth(AutT(2,3));
 #! 3
 #! @EndExampleSession
+
+#! @Arguments G
+#!
+DeclareOperation( "Depth", [IsRegularRootedTreeGroup] );
+
+# TODO document after https://github.com/gap-packages/AutoDoc/issues/174 is resolved
+DeclareSynonym( "Level", Depth );
+
+#! @EndGroup
 
 ##################################################################################################################
 

--- a/gap/SRGroups.gd
+++ b/gap/SRGroups.gd
@@ -168,7 +168,7 @@ DeclareGlobalFunction( "RemoveConjugates" );
 ##################################################################################################################
 
 #! @Description
-#! The argument of this property is aa regular rooted tree group <A>G</A>.
+#! The argument of this property is a regular rooted tree group <A>G</A>.
 #!
 #! @Returns
 #! <K>true</K> if <A>G</A> is self-replicating, and <K>false</K> otherwise.

--- a/gap/SRGroups.gd
+++ b/gap/SRGroups.gd
@@ -62,6 +62,7 @@ DeclareCategory("IsRegularRootedTreeGroup", IsPermGroup);
 #! @BeginGroup RegularRootedTreeGroupDegree
 #! @Description
 #! The argument of this attribute is a regular rooted tree group <A>G</A>.
+#! You can also use <A>Degree</A>.
 #!
 #! @Returns
 #! The degree of <A>G</A>.
@@ -74,10 +75,6 @@ DeclareAttribute("RegularRootedTreeGroupDegree", IsRegularRootedTreeGroup);
 #! gap> RegularRootedTreeGroupDegree(AutT(2,3));
 #! 2
 #! @EndExampleSession
-
-#! @Arguments G
-#!
-DeclareOperation( "Degree", [IsRegularRootedTreeGroup] );
 #! @EndGroup
 
 ##################################################################################################################
@@ -106,6 +103,19 @@ DeclareOperation( "Depth", [IsRegularRootedTreeGroup] );
 DeclareSynonym( "Level", Depth );
 
 #! @EndGroup
+
+##################################################################################################################
+
+#! @Description
+#! The argument of this attribute is a regular rooted tree group <A>G</A>.
+#!
+#! @Returns
+#! The <Ref Attr="Size" BookName="Reference"/> of the <Ref Attr="MinimalGeneratingSet" BookName="Reference"/>.
+#!
+#! @Arguments G
+#!
+DeclareAttribute("MinimalGeneratingSetSize", IsRegularRootedTreeGroup);
+
 
 ##################################################################################################################
 

--- a/gap/SRGroups.gi
+++ b/gap/SRGroups.gi
@@ -6,6 +6,11 @@
 #
 ##################################################################################################################
 
+InstallMethod(Degree, "for SRGroup", [IsRegularRootedTreeGroup], RegularRootedTreeGroupDegree);
+InstallMethod(Depth, "for SRGroup", [IsRegularRootedTreeGroup], RegularRootedTreeGroupDepth);
+
+##################################################################################################################
+
 # Input::	k: integer at least 2, n: integer at least 2, G: a subgroup of the automorphism group of the k-regular rooted tree of depth n
 # Output::	the regular rooted tree group G
 InstallMethod( RegularRootedTreeGroup, "for k,n,G (creator)", [IsInt, IsInt, IsPermGroup],

--- a/gap/SRGroups.gi
+++ b/gap/SRGroups.gi
@@ -8,6 +8,10 @@
 
 InstallMethod(Degree, "for SRGroup", [IsRegularRootedTreeGroup], RegularRootedTreeGroupDegree);
 InstallMethod(Depth, "for SRGroup", [IsRegularRootedTreeGroup], RegularRootedTreeGroupDepth);
+InstallMethod(MinimalGeneratingSetSize, "for SRGroup", [IsRegularRootedTreeGroup],
+function(G)
+    return Size(MinimalGeneratingSet(G));
+end );
 
 ##################################################################################################################
 

--- a/gap/library.gd
+++ b/gap/library.gd
@@ -120,9 +120,6 @@ DeclareGlobalFunction( "OneSRGroup" );
 
 ##################################################################################################################
 
-DeclareOperation( "Depth", [IsRegularRootedTreeGroup] );
-DeclareSynonym( "Level", Depth );
-
 #! @Description
 #! The arguments of this function are a non-zero number of pairs of a function applicable to self-replicating groups and a value, or list of values, that the function may return. It acts analogously to the function <C>AllTransitiveGroups</C> from the package <Package>transgrp</Package> of transitive groups. Special examples of applicable functions are:
 #!

--- a/gap/library.gd
+++ b/gap/library.gd
@@ -152,20 +152,17 @@ DeclareGlobalFunction( "OneSRGroup" );
 #! @Description
 #! The arguments of this function are a non-zero number of pairs of a function applicable to self-replicating groups and a value, or list of values, that the function may return. It is this library's version of <Ref Func="AllLibraryGroups" BookName="Reference"/>. Special examples of applicable functions are:
 #!
-#! <A>Degree</A>: the <Ref Attr="Degree" Label="for IsRegularRootedTreeGroup"/> of the group.
+#! <A>Degree</A> (int>1): the <Ref Attr="Degree" Label="for IsRegularRootedTreeGroup"/> of the group.
 #!
-#! <A>Depth</A> (or <A>Level</A>): the <Ref Attr="Depth" Label="for IsRegularRootedTreeGroup"/> of the group.
+#! <A>Depth</A> (or <A>Level</A>) (int>0): the <Ref Attr="Depth" Label="for IsRegularRootedTreeGroup"/> of the group.
 #!
-#! <A>ChildGroupsCount</A>: the number of <Ref Attr="ChildGroups" Label="for IsRegularRootedTreeGroup"/>.
+#! <A>SRGroupNumber</A> (int>0): Restricts the index in the library.
 #!
-#! <A>ParentGroup</A>: Restricts returned groups to have a given <Ref Attr="ParentGroup" Label="for IsRegularRootedTreeGroup"/>, this gives the projection.
+#! <A>ChildGroupsCount</A> (int>0): the number of <Ref Attr="ChildGroups" Label="for IsRegularRootedTreeGroup"/>.
 #!
-#! <A>SRGroupNumber</A>: Restricts the index in the library.
+#! <A>ParentGroup</A> (SRGroup): Restricts returned groups to have a given <Ref Attr="ParentGroup" Label="for IsRegularRootedTreeGroup"/>, this gives the projection.
 #!
-# TODO is there a bug here? - Yes
-# gap> AllSRGroups(Degree,2,Depth,2,IsSubgroup,1);
-# [ SRGroup(2,2,1), SRGroup(2,2,2), SRGroup(2,2,3) ]
-#! <A>IsSubgroup</A> (int > 0) := groups that are a subgroup of the group number provided
+#! <A>IsSubgroup</A> (Group) := groups that are a subgroup of the group provided
 #!
 #! <A>MinimalGeneratingSetSize</A> (int > 0) := size of the group's minimal generating set
 #!

--- a/gap/library.gd
+++ b/gap/library.gd
@@ -116,7 +116,7 @@ DeclareGlobalFunction( "SRGroup" );
 
 ##################################################################################################################
 
-#! @BeginGroup ChildrenGroups
+#! @BeginGroup ChildGroups
 
 #! @Description
 #! Finds all the self-replicating groups that have G as a parent
@@ -176,18 +176,17 @@ DeclareGlobalFunction( "OneSRGroup" );
 #!
 DeclareGlobalFunction("AllSRGroups");
 #!
-# TODO(cameron) redo the example
 #! @BeginExampleSession
 #! gap> AllSRGroups(Degree, 2, Level, 4, IsAbelian, true);
-#! [ SRGroup(2,4,2), SRGroup(2,4,9), SRGroup(2,4,12), SRGroup(2,4,14) ]
-#! gap> AllSRGroups(Degree,[2..5],Depth,[2..5],IsSubgroup,[1..5]);
-#! Restricting degrees to [ 2, 3 ]
-#! [ SRGroup(2,1,1), SRGroup(2,1,1), SRGroup(2,2,1), SRGroup(2,3,1),
-#!   SRGroup(2,3,2), SRGroup(2,4,1), SRGroup(2,4,1), SRGroup(2,4,2),
-#!   SRGroup(2,4,2), SRGroup(2,4,2), SRGroup(3,1,1), SRGroup(3,1,1),
-#!   SRGroup(3,1,1), SRGroup(3,1,1) ]
-#! gap> AllSRGroups(Degree,2,Depth,[2..3],ParentGroup,SRGroup(2,1,1));
-#! [ SRGroup(2,2,1), SRGroup(2,2,2), SRGroup(2,2,3) ]
+#! [ SRGroup(2,4,1), SRGroup(2,4,9), SRGroup(2,4,13), SRGroup(2,4,14) ]
+#! gap> AllSRGroups(Degree,2,Depth,5,IsSubgroup,[SRGroup(2,1,1), SRGroup(2,2,1)], ParentGroup, SRGroup(2,4,118));
+#! [ SRGroup(2,5,2332), SRGroup(2,5,2341), SRGroup(2,5,2342), SRGroup(2,5,2343), SRGroup(2,5,2344), SRGroup(2,5,2345),
+#!   SRGroup(2,5,2346), SRGroup(2,5,2347), SRGroup(2,5,2348), SRGroup(2,5,2364), SRGroup(2,5,2366), SRGroup(2,5,2368),
+#!   SRGroup(2,5,2371), SRGroup(2,5,2373), SRGroup(2,5,2375), SRGroup(2,5,2384), SRGroup(2,5,2387), SRGroup(2,5,2388),
+#!   SRGroup(2,5,2410), SRGroup(2,5,2411), SRGroup(2,5,2412), SRGroup(2,5,2413), SRGroup(2,5,2422), SRGroup(2,5,2425),
+#!   SRGroup(2,5,2426), SRGroup(2,5,2433), SRGroup(2,5,2434), SRGroup(2,5,2435), SRGroup(2,5,2436) ]
+#! gap> AllSRGroups(Degree,[2..5],Depth,[2..5],MinimalGeneratingSetSize,1);
+#! [ SRGroup(2,2,1), SRGroup(2,3,1), SRGroup(2,4,1), SRGroup(2,5,2), SRGroup(3,2,4) ]
 #! @EndExampleSession
 
 ##################################################################################################################

--- a/gap/library.gd
+++ b/gap/library.gd
@@ -123,22 +123,25 @@ DeclareGlobalFunction( "OneSRGroup" );
 #! @Description
 #! The arguments of this function are a non-zero number of pairs of a function applicable to self-replicating groups and a value, or list of values, that the function may return. It acts analogously to the function <C>AllTransitiveGroups</C> from the package <Package>transgrp</Package> of transitive groups. Special examples of applicable functions are:
 #!
-#! <A>Degree</A>: short hand for <Ref Attr="RegularRootedTreeGroupDepth" Label="for IsRegularRootedTreeGroup"/>.
+#! <A>Degree</A>: The <Ref Attr="Degree" Label="for IsRegularRootedTreeGroup"/> of the group.
 #!
-#! <A>Depth</A> (or <A>Level</A>): short hand for <Ref Attr="RegularRootedTreeGroupDepth" Label="for IsRegularRootedTreeGroup"/>.
+#! <A>Depth</A> (or <A>Level</A>): The <Ref Attr="Depth" Label="for IsRegularRootedTreeGroup"/> of the group.
 #!
 # TODO perhaps a more useful filter would be the number of children?
-#! <A>Number</A>: the index <C>nr</C> in the library.
+#! <A>ChildCount</A>: the index <C>nr</C> in the library.
 #!
-#! <A>Projection</A>: the index <C>nr</C> of <Ref Attr="ParentGroup" Label="for IsRegularRootedTreeGroup"/> in the library.
+#! <A>ParentGroup</A>: Restricts returned groups to have a given parent, this gives the projection.
+#! @BeginExampleSession
+#! gap> AllSRGroups(Degree,2,Depth,[2..3],ParentGroup,SRGroup(2,1,1));
+#! [ SRGroup(2,2,1), SRGroup(2,2,2), SRGroup(2,2,3) ]
+#! @EndExampleSession
 #!
-# TODO is there a bug here?
+# TODO is there a bug here? - Yes
 # gap> AllSRGroups(Degree,2,Depth,2,IsSubgroup,1);
 # [ SRGroup(2,2,1), SRGroup(2,2,2), SRGroup(2,2,3) ]
 #! <A>IsSubgroup</A> (int > 0) := groups that are a subgroup of the group number provided
 #!
-# TODO this should be MinimalGeneratingSetSize to avoid conflict with the function MinimalGeneratingSet
-#! <A>MinimalGeneratingSet</A> (int > 0) := size of the group's minimal generating set
+#! <A>MinimalGeneratingSetSize</A> (int > 0) := size of the group's minimal generating set
 #!
 #! @Returns
 #! A list of all self-replicating groups that satisfy the parameters.

--- a/gap/library.gd
+++ b/gap/library.gd
@@ -116,25 +116,52 @@ DeclareGlobalFunction( "SRGroup" );
 
 ##################################################################################################################
 
+# TODO(cameron) work out where to put this.
+#! @BeginGroup ChildrenGroups
+
+#! @Description
+#! Finds all the self-replicating groups that have G as a parent
+#!
+#! @Returns
+#! A list of groups, the size of the list.
+#!
+#! @Arguments G
+DeclareAttribute("ChildGroups", IsRegularRootedTreeGroup);
+#! @Arguments G
+DeclareAttribute("ChildGroupsCount", IsRegularRootedTreeGroup);
+
+#! @EndGroup
+
+##################################################################################################################
+
+#! @Description
+#! Finds the index of the self-replicating group G in the library
+#!
+#! @Returns
+#! The index of G in the library
+#!
+#! @Arguments G
+DeclareAttribute("SRGroupNumber", IsRegularRootedTreeGroup);
+
+##################################################################################################################
+
+#!
 DeclareGlobalFunction( "OneSRGroup" );
 
 ##################################################################################################################
 
 #! @Description
-#! The arguments of this function are a non-zero number of pairs of a function applicable to self-replicating groups and a value, or list of values, that the function may return. It acts analogously to the function <C>AllTransitiveGroups</C> from the package <Package>transgrp</Package> of transitive groups. Special examples of applicable functions are:
+#! The arguments of this function are a non-zero number of pairs of a function applicable to self-replicating groups and a value, or list of values, that the function may return. It is this library's version of <Ref Func="AllLibraryGroups" BookName="Reference"/>. Special examples of applicable functions are:
 #!
-#! <A>Degree</A>: The <Ref Attr="Degree" Label="for IsRegularRootedTreeGroup"/> of the group.
+#! <A>Degree</A>: the <Ref Attr="Degree" Label="for IsRegularRootedTreeGroup"/> of the group.
 #!
-#! <A>Depth</A> (or <A>Level</A>): The <Ref Attr="Depth" Label="for IsRegularRootedTreeGroup"/> of the group.
+#! <A>Depth</A> (or <A>Level</A>): the <Ref Attr="Depth" Label="for IsRegularRootedTreeGroup"/> of the group.
 #!
-# TODO perhaps a more useful filter would be the number of children?
-#! <A>ChildCount</A>: the index <C>nr</C> in the library.
+#! <A>ChildGroupsCount</A>: the number of <Ref Attr="ChildGroups" Label="for IsRegularRootedTreeGroup"/>.
 #!
-#! <A>ParentGroup</A>: Restricts returned groups to have a given parent, this gives the projection.
-#! @BeginExampleSession
-#! gap> AllSRGroups(Degree,2,Depth,[2..3],ParentGroup,SRGroup(2,1,1));
-#! [ SRGroup(2,2,1), SRGroup(2,2,2), SRGroup(2,2,3) ]
-#! @EndExampleSession
+#! <A>ParentGroup</A>: Restricts returned groups to have a given <Ref Attr="ParentGroup" Label="for IsRegularRootedTreeGroup"/>, this gives the projection.
+#!
+#! <A>SRGroupNumber</A>: Restricts the index in the library.
 #!
 # TODO is there a bug here? - Yes
 # gap> AllSRGroups(Degree,2,Depth,2,IsSubgroup,1);
@@ -153,12 +180,14 @@ DeclareGlobalFunction("AllSRGroups");
 #! @BeginExampleSession
 #! gap> AllSRGroups(Degree, 2, Level, 4, IsAbelian, true);
 #! [ SRGroup(2,4,2), SRGroup(2,4,9), SRGroup(2,4,12), SRGroup(2,4,14) ]
-#! gap> AllSRGroups(Degree,[2..5],Depth,[2..5],IsSubgroup,[1..5],Projection,[1..3]);
+#! gap> AllSRGroups(Degree,[2..5],Depth,[2..5],IsSubgroup,[1..5]);
 #! Restricting degrees to [ 2, 3 ]
 #! [ SRGroup(2,1,1), SRGroup(2,1,1), SRGroup(2,2,1), SRGroup(2,3,1),
 #!   SRGroup(2,3,2), SRGroup(2,4,1), SRGroup(2,4,1), SRGroup(2,4,2),
 #!   SRGroup(2,4,2), SRGroup(2,4,2), SRGroup(3,1,1), SRGroup(3,1,1),
 #!   SRGroup(3,1,1), SRGroup(3,1,1) ]
+#! gap> AllSRGroups(Degree,2,Depth,[2..3],ParentGroup,SRGroup(2,1,1));
+#! [ SRGroup(2,2,1), SRGroup(2,2,2), SRGroup(2,2,3) ]
 #! @EndExampleSession
 
 ##################################################################################################################

--- a/gap/library.gd
+++ b/gap/library.gd
@@ -144,11 +144,8 @@ DeclareAttribute("SRGroupNumber", IsSelfReplicating);
 
 ##################################################################################################################
 
-#!
-DeclareGlobalFunction( "OneSRGroup" );
-
-##################################################################################################################
-
+#! @BeginGroup AllSRGroups
+#! @GroupTitle Selection Functions
 #! @Description
 #! The arguments of this function are a non-zero number of pairs of a function applicable to self-replicating groups and a value, or list of values, that the function may return. It is this library's version of <Ref Func="AllLibraryGroups" BookName="Reference"/>. Special examples of applicable functions are:
 #!
@@ -156,9 +153,9 @@ DeclareGlobalFunction( "OneSRGroup" );
 #!
 #! <A>Depth</A> (or <A>Level</A>) (int>0): the <Ref Attr="Depth" Label="for IsRegularRootedTreeGroup"/> of the group.
 #!
-#! <A>SRGroupNumber</A> (int>0): Restricts the index in the library.
+#! <A>SRGroupNumber</A> (int>0): Restricts the <Ref Attr="SRGroupNumber" Label="for IsSelfReplicating"/> in the library.
 #!
-#! <A>ChildGroupsCount</A> (int>0): the number of <Ref Attr="ChildGroups" Label="for IsRegularRootedTreeGroup"/>.
+#! <A>ChildGroupsCount</A> (int>0): the number of <Ref Attr="ChildGroups" Label="for IsSelfReplicating"/>.
 #!
 #! <A>ParentGroup</A> (SRGroup): Restricts returned groups to have a given <Ref Attr="ParentGroup" Label="for IsRegularRootedTreeGroup"/>, this gives the projection.
 #!
@@ -167,7 +164,11 @@ DeclareGlobalFunction( "OneSRGroup" );
 #! <A>MinimalGeneratingSetSize</A> (int > 0) := size of the group's minimal generating set
 #!
 #! @Returns
-#! A list of all self-replicating groups that satisfy the parameters.
+#! A one or a list of all self-replicating groups that satisfy the parameters.
+#!
+#! @Arguments fun1, val1, fun2, val2, ...
+#!
+DeclareGlobalFunction( "OneSRGroup" );
 #!
 #! @Arguments fun1, val1, fun2, val2, ...
 #!
@@ -185,6 +186,7 @@ DeclareGlobalFunction("AllSRGroups");
 #! gap> AllSRGroups(Degree,[2..5],Depth,[2..5],MinimalGeneratingSetSize,1);
 #! [ SRGroup(2,2,1), SRGroup(2,3,1), SRGroup(2,4,1), SRGroup(2,5,2), SRGroup(3,2,4) ]
 #! @EndExampleSession
+#! @EndGroup
 
 ##################################################################################################################
 

--- a/gap/library.gd
+++ b/gap/library.gd
@@ -116,7 +116,6 @@ DeclareGlobalFunction( "SRGroup" );
 
 ##################################################################################################################
 
-# TODO(cameron) work out where to put this.
 #! @BeginGroup ChildrenGroups
 
 #! @Description
@@ -126,9 +125,9 @@ DeclareGlobalFunction( "SRGroup" );
 #! A list of groups, the size of the list.
 #!
 #! @Arguments G
-DeclareAttribute("ChildGroups", IsRegularRootedTreeGroup);
+DeclareAttribute("ChildGroups", IsSelfReplicating);
 #! @Arguments G
-DeclareAttribute("ChildGroupsCount", IsRegularRootedTreeGroup);
+DeclareAttribute("ChildGroupsCount", IsSelfReplicating);
 
 #! @EndGroup
 
@@ -141,7 +140,7 @@ DeclareAttribute("ChildGroupsCount", IsRegularRootedTreeGroup);
 #! The index of G in the library
 #!
 #! @Arguments G
-DeclareAttribute("SRGroupNumber", IsRegularRootedTreeGroup);
+DeclareAttribute("SRGroupNumber", IsSelfReplicating);
 
 ##################################################################################################################
 
@@ -177,6 +176,7 @@ DeclareGlobalFunction( "OneSRGroup" );
 #!
 DeclareGlobalFunction("AllSRGroups");
 #!
+# TODO(cameron) redo the example
 #! @BeginExampleSession
 #! gap> AllSRGroups(Degree, 2, Level, 4, IsAbelian, true);
 #! [ SRGroup(2,4,2), SRGroup(2,4,9), SRGroup(2,4,12), SRGroup(2,4,14) ]

--- a/gap/library.gd
+++ b/gap/library.gd
@@ -120,7 +120,8 @@ DeclareGlobalFunction( "OneSRGroup" );
 
 ##################################################################################################################
 
-DeclareSynonym( "Level" , "Depth" );
+DeclareOperation( "Depth", [IsRegularRootedTreeGroup] );
+DeclareSynonym( "Level", Depth );
 
 #! @Description
 #! The arguments of this function are a non-zero number of pairs of a function applicable to self-replicating groups and a value, or list of values, that the function may return. It acts analogously to the function <C>AllTransitiveGroups</C> from the package <Package>transgrp</Package> of transitive groups. Special examples of applicable functions are:

--- a/gap/library.gi
+++ b/gap/library.gi
@@ -120,7 +120,7 @@ end);
 
 ##################################################################################################################
 
-InstallMethod(ChildGroups, "for G", [IsRegularRootedTreeGroup],
+InstallMethod(ChildGroups, "for G", [IsSelfReplicating],
 function(G)
     local groups, data, name, k, n, nr;
     k := Degree(G);
@@ -128,6 +128,7 @@ function(G)
     nr := SRGroupNumber(G);
     data := SRGroupData(k, n, nr)[4];
     groups := [];
+    # TODO(cameron) this is slower than expected
     for name in data do
         if name = "the classes it extends to" then
             return fail;
@@ -137,16 +138,37 @@ function(G)
     return groups;
 end );
 
-InstallMethod(ChildGroupsCount, "for G", [IsRegularRootedTreeGroup],
+InstallMethod(ChildGroupsCount, "for G", [IsSelfReplicating],
 function(G)
-    return Size(ChildGroups(G));
+    local data, k, n, nr;
+    k := Degree(G);
+    n := Depth(G);
+    nr := SRGroupNumber(G);
+    data := SRGroupData(k, n, nr)[4];
+    return Size(data);
 end );
 
 ##################################################################################################################
 
-InstallMethod(SRGroupNumber, "for G", [IsRegularRootedTreeGroup],
+InstallMethod(SRGroupNumber, "for G", [IsSelfReplicating],
 function(G)
-    return EvalString(SplitString(SplitString(Name(G),",")[3],")")[1]);
+    local n, k, i, candidate;
+    if HasName(G) and StartsWith(Name(G), "SRGroup") then
+        # Just read it
+        return EvalString(SplitString(SplitString(Name(G),",")[3],")")[1]);
+    else
+        # TODO(cameron) Find a more efficient way of doing this.
+        k := Degree(G);
+        n := Depth(G);
+        i := 0;
+        for candidate in AllSRGroups(Depth,n,Degree,k) do
+            i := i + 1;
+            if candidate = G then
+                return i;
+            fi;
+        od;
+    fi;
+    return fail;
 end );
 
 ##################################################################################################################

--- a/gap/library.gi
+++ b/gap/library.gi
@@ -141,10 +141,6 @@ end);
 
 ##################################################################################################################
 
-InstallMethod(Depth, "for SRGroup", [IsRegularRootedTreeGroup], RegularRootedTreeGroupDepth);
-
-##################################################################################################################
-
 # TODO: make this quicker by searching for degree AND level first
 # internal
 InstallGlobalFunction( SelectSRGroups,

--- a/gap/library.gi
+++ b/gap/library.gi
@@ -194,11 +194,10 @@ end);
 
 ##################################################################################################################
 
-# TODO: make this quicker by searching for degree AND level first
 # internal
 InstallGlobalFunction( SelectSRGroups,
 function(args,all)
-	local k, n, nr, groups, degree, groups_temp, names, i, j;
+	local k, n, nr, groups, degree, level, groups_temp, names, i, j;
 	
 	if not IsInt(Length(args)/2) then
 		Error("argument must be of the form fun1,val1,fun2,val2,...");
@@ -214,10 +213,18 @@ function(args,all)
 		fi;
 
 		groups:=[];
-		for degree in k do
-			for n in SRLevels(degree) do
+		for degree in k do   
+            if not Position(args,Depth)=fail then
+                n := args[Position(args,Depth)+1];
+                if not IsList(n) then n:=[n]; fi;
+                n := Intersection(SRLevels(degree), n);
+            else
+                n := SRLevels(degree);
+            fi;
+
+			for level in n do
 				# get groups from library and name them
-				groups_temp:=SRGroupsData(degree,n);
+				groups_temp:=SRGroupsData(degree,level);
 				names:=ShallowCopy(groups_temp);
 				Apply(names,G->G[2]);
 				Apply(groups_temp,G->RegularRootedTreeGroup(EvalString(SplitString(G[2],",","(")[2]),EvalString(SplitString(G[2],",")[2]),Group(G[1])));

--- a/gap/library.gi
+++ b/gap/library.gi
@@ -128,7 +128,6 @@ function(G)
     nr := SRGroupNumber(G);
     data := SRGroupData(k, n, nr)[4];
     groups := [];
-    # TODO(cameron) this is slower than expected
     for name in data do
         if name = "the classes it extends to" then
             return fail;
@@ -199,10 +198,12 @@ InstallGlobalFunction( SelectSRGroups,
 function(args,all)
 	local k, n, nr, groups, degree, level, groups_temp, names, i, j;
 	
+    # TODO(cameron) more input checking
 	if not IsInt(Length(args)/2) then
 		Error("argument must be of the form fun1,val1,fun2,val2,...");
 	else	
 		# pre-select groups by desired degree(s)
+        # TODO(cameron) mention if we filter out degrees or depths
 		if not Position(args,Degree)=fail then
 			k:=args[Position(args,Degree)+1];
 			if not IsList(k) then k:=[k]; fi;

--- a/gap/library.gi
+++ b/gap/library.gi
@@ -173,21 +173,6 @@ function(args,all)
 			od;
 		od;
 		
-		# sieve by depth
-		if not Position(args,Depth)=fail then
-			n:=args[Position(args,Depth)+1];
-			if not IsList(n) then n:=[n]; fi;
-			Remove(args,Position(args,Depth)+1);
-			Remove(args,Position(args,Depth));
-		else
-			n:=fail;
-		fi;		
-		if not n=fail then
-			for i in [Length(groups),Length(groups)-1..1] do
-				if not RegularRootedTreeGroupDepth(groups[i]) in n then Remove(groups,i); fi;
-			od;
-		fi;
-
 		# sieve by number
 		if not Position(args,Number)=fail then
 			nr:=args[Position(args,Number)+1];
@@ -207,7 +192,7 @@ function(args,all)
 		if not args=[] then
 			for i in [1..Length(groups)] do
 				for j in [1..Length(args)/2] do
-					if not args[2*j-1](groups[i])=args[2*j] then
+					if not STGSelFunc(args[2*j-1](groups[i]),args[2*j]) then
 						Unbind(groups[i]);
 						break;
 					fi;

--- a/gap/library.gi
+++ b/gap/library.gi
@@ -120,6 +120,37 @@ end);
 
 ##################################################################################################################
 
+InstallMethod(ChildGroups, "for G", [IsRegularRootedTreeGroup],
+function(G)
+    local groups, data, name, k, n, nr;
+    k := Degree(G);
+    n := Depth(G);
+    nr := SRGroupNumber(G);
+    data := SRGroupData(k, n, nr)[4];
+    groups := [];
+    for name in data do
+        if name = "the classes it extends to" then
+            return fail;
+        fi;
+        Add(groups, EvalString(name));
+    od;
+    return groups;
+end );
+
+InstallMethod(ChildGroupsCount, "for G", [IsRegularRootedTreeGroup],
+function(G)
+    return Size(ChildGroups(G));
+end );
+
+##################################################################################################################
+
+InstallMethod(SRGroupNumber, "for G", [IsRegularRootedTreeGroup],
+function(G)
+    return EvalString(SplitString(SplitString(Name(G),",")[3],")")[1]);
+end );
+
+##################################################################################################################
+
 InstallGlobalFunction( OneSRGroup,
 function(args...)
 	local group;
@@ -173,21 +204,6 @@ function(args,all)
 			od;
 		od;
 		
-		# sieve by number
-		if not Position(args,Number)=fail then
-			nr:=args[Position(args,Number)+1];
-			if not IsList(nr) then nr:=[nr]; fi;
-			Remove(args,Position(args,Number)+1);
-			Remove(args,Position(args,Number));
-		else
-			nr:=fail;
-		fi;
-		if not nr=fail then
-			for i in [Length(groups),Length(groups)-1..1] do
-				if not EvalString(SplitString(SplitString(Name(groups[i]),",")[3],")")[1]) in nr then Remove(groups,i); fi;
-			od;
-		fi;
-
 		# sieve by all remaining properties
 		if not args=[] then
 			for i in [1..Length(groups)] do

--- a/gap/library.gi
+++ b/gap/library.gi
@@ -141,6 +141,10 @@ end);
 
 ##################################################################################################################
 
+InstallMethod(Depth, "for SRGroup", [IsRegularRootedTreeGroup], RegularRootedTreeGroupDepth);
+
+##################################################################################################################
+
 # TODO: make this quicker by searching for degree AND level first
 # internal
 InstallGlobalFunction( SelectSRGroups,
@@ -516,12 +520,8 @@ InstallGlobalFunction(AllSRGroupsInfo,function(arg)
 		Add(inputArgs,0);
 	fi;
 	
-	if IsInt(Position(arg,Depth)) or IsInt(Position(arg,Level)) then
-		if IsInt(Position(arg,Depth)) then
-			Add(inputArgs,arg[Position(arg,Depth)+1]);
-		elif IsInt(Position(arg,Level)) then
-			Add(inputArgs,arg[Position(arg,Level)+1]);
-		fi;
+	if IsInt(Position(arg,Depth)) then
+		Add(inputArgs,arg[Position(arg,Depth)+1]);
 	else
 		Add(inputArgs,0);
 	fi;

--- a/gap/library.gi
+++ b/gap/library.gi
@@ -176,7 +176,7 @@ end);
 # internal
 InstallGlobalFunction( SelectSRGroups,
 function(args,all)
-	local k, n, nr, groups, degree, groups_temp, names, i, j, works;
+	local k, n, nr, groups, degree, groups_temp, names, i, j;
 	
 	if not IsInt(Length(args)/2) then
 		Error("argument must be of the form fun1,val1,fun2,val2,...");
@@ -208,10 +208,28 @@ function(args,all)
 		if not args=[] then
 			for i in [1..Length(groups)] do
 				for j in [1..Length(args)/2] do
-					if not STGSelFunc(args[2*j-1](groups[i]),args[2*j]) then
-						Unbind(groups[i]);
-						break;
-					fi;
+                    if AbsoluteValue(NumberArgumentsFunction(args[2*j-1])) = 2 then
+                        # For binary functions
+                        if IsList(args[2*j]) then
+                            if not ForAny(args[2*j], x->args[2*j-1](groups[i],x)) then
+                                Unbind(groups[i]);
+                                break;
+                            fi;
+                        else
+                            if not args[2*j-1](groups[i], args[2*j]) then
+                                Unbind(groups[i]);
+                                break;
+                            fi;
+                        fi;
+                    elif AbsoluteValue(NumberArgumentsFunction(args[2*j-1])) = 1 then
+                        # For operations and unary functions
+                        if not STGSelFunc(args[2*j-1](groups[i]),args[2*j]) then
+                            Unbind(groups[i]);
+                            break;
+                        fi;
+                    else
+                        Error("Function at position ", 2*j-1, " requires more than two parameters.");
+                    fi;
 				od;
 				if not all and IsBound(groups[i]) then return groups[i]; fi;
 			od;


### PR DESCRIPTION
This PR adds a function `GrigorchukProjectedGroup(depth)` that calculates the permutation group which is the approximation of the Grigorchuk group.

Some calculation tells us that these groups are equal to
- `SRGroup(2,2,3)` = Aut
- `SRGroup(2,3,15)` = Aut
- `SRGroup(2,4,107)`
- `SRGroup(2,5,2187)`

(I've got commits from #4 in here, so merge that one first.)